### PR TITLE
Resque_Redis: use `&&` rather than `and`

### DIFF
--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -98,7 +98,7 @@ class Resque_Redis
 	 */
 	public static function prefix($namespace)
 	{
-	    if (substr($namespace, -1) !== ':' and $namespace != '') {
+	    if (substr($namespace, -1) !== ':' && $namespace != '') {
 	        $namespace .= ':';
 	    }
 	    self::$defaultNamespace = $namespace;


### PR DESCRIPTION
`and` operator has different functionality (and priority) than `&&` operator (which is supposed to be there).

Even though it doesn't seem to cause harm in this case, it should still be fixed.

Thanks!
